### PR TITLE
Prevent Hatch from accessing keyring during publish

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -49,3 +49,4 @@ jobs:
       env:
         HATCH_INDEX_USER: __token__
         HATCH_INDEX_AUTH: ${{ secrets.PYPI_TOKEN }}
+        HATCH_INDEX_DISABLE_KEYRING: "1" #prevents Hatch from touching keyring


### PR DESCRIPTION
Added HATCH_INDEX_DISABLE_KEYRING to prevent keyring access.